### PR TITLE
Remove Nova 5 constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.0",
-        "laravel/nova": "^4.0|^5.0",
+        "laravel/nova": "^4.0",
         "spatie/cpu-load-health-check": "^1.0",
         "spatie/laravel-health": "^1.9",
         "spatie/ssl-certificate": "^2.6"


### PR DESCRIPTION
My bad. Nova 5 is not compatible with the icons, so I removed the constraint. PR for v5 follows.